### PR TITLE
fix(ci): skip redundant apt install on Playwright cache hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,29 +81,15 @@ jobs:
 
       - name: Restore Playwright browser cache
         id: playwright-cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ github.run_id }}
-          restore-keys: playwright-${{ steps.playwright-version.outputs.version }}-
+          key: playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
-        id: playwright-install
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
         working-directory: packages/frontend
-
-      - name: Verify Playwright browsers (cache hit)
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install
-        working-directory: packages/frontend
-
-      - name: Save Playwright browser cache
-        if: steps.playwright-install.outcome == 'success'
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.playwright-version.outputs.version }}-${{ github.run_id }}
 
       - name: Run E2E tests
         run: npx playwright test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,9 @@ jobs:
         run: npx playwright install --with-deps
         working-directory: packages/frontend
 
-      - name: Install Playwright system deps (cache hit)
+      - name: Verify Playwright browsers (cache hit)
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps
+        run: npx playwright install
         working-directory: packages/frontend
 
       - name: Save Playwright browser cache


### PR DESCRIPTION
## Summary
- Replace `npx playwright install-deps` with `npx playwright install` on Playwright browser cache hit
- `install-deps` runs `apt install` for ~180 OS packages (~11 min) even when browser binaries are already cached — `ubuntu-latest` runner image already has these system libraries
- On cache miss, `--with-deps` still installs both browsers and OS deps as before

## Test plan
- [ ] CI e2e job completes with Playwright cache hit (verify "Verify Playwright browsers" step runs in seconds, not minutes)
- [ ] E2E tests still pass (system libraries available on runner image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)