### PR TITLE
fix(tests): fix mobile E2E toggle bug and suppress CI test noise

### DIFF
--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -18,6 +18,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "isolatedModules": true,
     "skipLibCheck": true,
     "typeRoots": ["./node_modules/@types", "../node_modules/@types"],
     "types": ["node", "jest"]

--- a/packages/backend/src/handlers/__tests__/auth-callback.test.ts
+++ b/packages/backend/src/handlers/__tests__/auth-callback.test.ts
@@ -67,6 +67,7 @@ describe('auth-callback handler', () => {
   });
 
   it('returns 500 on spotify API failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(exchangeCodeForTokens).mockRejectedValue(new Error('bad code'));
 
     const result = await invoke({ code: 'bad' });

--- a/packages/backend/src/handlers/__tests__/auth-refresh.test.ts
+++ b/packages/backend/src/handlers/__tests__/auth-refresh.test.ts
@@ -65,6 +65,7 @@ describe('auth-refresh handler', () => {
   });
 
   it('returns 500 on refresh failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(getSession).mockResolvedValue({
       spotifyUserId: 'user1',
       refreshToken: 'rt_old',

--- a/packages/backend/src/handlers/__tests__/settings-load.test.ts
+++ b/packages/backend/src/handlers/__tests__/settings-load.test.ts
@@ -89,6 +89,7 @@ describe('settings-load handler', () => {
   });
 
   it('returns 500 on dynamo failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(getSession).mockRejectedValue(new Error('DynamoDB error'));
     const result = await invoke({ sessionId: 'sess_1' });
     expect(result.statusCode).toBe(500);

--- a/packages/backend/src/handlers/__tests__/settings-save.test.ts
+++ b/packages/backend/src/handlers/__tests__/settings-save.test.ts
@@ -96,6 +96,7 @@ describe('settings-save handler', () => {
   });
 
   it('returns 500 on dynamo failure', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.mocked(getSession).mockRejectedValue(new Error('DynamoDB error'));
     const result = await invoke({ sessionId: 'sess_1', settings: mockSettings });
     expect(result.statusCode).toBe(500);

--- a/packages/frontend/e2e/mobile.spec.ts
+++ b/packages/frontend/e2e/mobile.spec.ts
@@ -11,6 +11,14 @@ async function revealControls(app: Page) {
   await app.waitForTimeout(500);
 }
 
+/** Ensure controls are visible — reveal them if they've auto-hidden. */
+async function ensureControlsVisible(app: Page) {
+  const isHidden = await app
+    .locator('[data-testid="mobile-circle"]')
+    .evaluate((el) => el.classList.contains('opacity-0'));
+  if (isHidden) await revealControls(app);
+}
+
 /** Get a locator scoped to the mobile control circle. */
 function mobileButton(app: Page, label: string): Locator {
   return app.locator('[data-testid="mobile-circle"]').getByLabel(label, { exact: true });
@@ -45,23 +53,20 @@ test.describe('Mobile UI', () => {
   });
 
   test('controls are visible after launch', async ({ app }) => {
-    // Re-reveal to ensure fresh idle timer — beforeEach may have consumed it
-    await revealControls(app);
+    await ensureControlsVisible(app);
     await expect(mobileButton(app, 'Presets')).toBeVisible();
     await expect(mobileButton(app, 'Settings')).toBeVisible();
     await expect(mobileButton(app, 'Next')).toBeVisible();
   });
 
   test('controls hide after idle timeout', async ({ app }) => {
-    // Re-reveal to reset the 5s idle timer with a known start time —
-    // beforeEach may have consumed part of the timer already.
-    await revealControls(app);
-    await expectControlsVisible(app, 3000);
-    // Idle timer is 5s — controls should fade out
+    // beforeEach confirmed controls are visible. The 5s idle timer is already
+    // running — just wait for controls to fade out (10s timeout is generous).
     await expectControlsHidden(app);
   });
 
   test('tap hides visible controls', async ({ app }) => {
+    await ensureControlsVisible(app);
     // Tap the overlay to trigger forceIdle → controls fade out
     await app.locator('div[role="presentation"]').dispatchEvent('click');
     await expectControlsHidden(app, 3000);
@@ -73,27 +78,20 @@ test.describe('Mobile UI', () => {
     const initial = await presetName.textContent();
 
     await expect(async () => {
-      // Re-reveal if controls have auto-hidden
-      const isHidden = await app
-        .locator('[data-testid="mobile-circle"]')
-        .evaluate((el) => el.classList.contains('opacity-0'));
-      if (isHidden) await revealControls(app);
-
+      await ensureControlsVisible(app);
       await mobileButton(app, 'Next').dispatchEvent('click');
       await expect(presetName).not.toHaveText(initial ?? '', { timeout: 2000 });
     }).toPass({ timeout: 20000 });
   });
 
   test('Presets button opens modal panel', async ({ app }) => {
-    // Re-reveal in case idle timer fired during beforeEach
-    await revealControls(app);
+    await ensureControlsVisible(app);
     await mobileButton(app, 'Presets').dispatchEvent('click');
     await expect(app.locator('[role="dialog"]').first()).toBeVisible({ timeout: 5000 });
   });
 
   test('Settings button opens modal panel', async ({ app }) => {
-    // Re-reveal in case idle timer fired during beforeEach
-    await revealControls(app);
+    await ensureControlsVisible(app);
     await mobileButton(app, 'Settings').dispatchEvent('click');
     await expect(app.locator('[role="dialog"]').first()).toBeVisible({ timeout: 5000 });
   });

--- a/packages/frontend/src/components/__tests__/RateLimitToast.test.tsx
+++ b/packages/frontend/src/components/__tests__/RateLimitToast.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { RateLimitToast } from '../RateLimitToast.tsx';
 import { useSpotifyStore } from '../../store/useSpotifyStore.ts';
 
@@ -47,7 +47,9 @@ describe('RateLimitToast', () => {
     const { rerender } = render(<RateLimitToast />);
     expect(screen.getByText(/Spotify rate limited/)).toBeInTheDocument();
 
-    useSpotifyStore.setState({ isRateLimited: false, rateLimitResetsAt: null });
+    act(() => {
+      useSpotifyStore.setState({ isRateLimited: false, rateLimitResetsAt: null });
+    });
     rerender(<RateLimitToast />);
     expect(screen.queryByText(/Spotify rate limited/)).toBeNull();
   });


### PR DESCRIPTION
## Summary
- **Mobile E2E toggle bug**: `revealControls()` dispatches a click that *toggles* visibility. When called with controls already visible, it hides them — causing `expectControlsVisible` to fail. Added `ensureControlsVisible()` helper that checks state first.
- **Idle timeout test**: Simplified to just wait for fade-out after `beforeEach` confirms visibility, instead of trying to re-reveal and race the 5s timer.
- **Test noise**: Mocked `console.error` in backend error-path tests, wrapped Zustand setState in `act()` for RateLimitToast, added `isolatedModules` to infrastructure tsconfig for ts-jest.

## Test plan
- [ ] CI E2E mobile tests pass (especially "controls hide after idle timeout")
- [ ] CI lint-and-test output is clean (no stderr, no act() warnings, no ts-jest warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)