### PR TITLE
fix(e2e): retry keyboard toast tests and increase CI workers

### DIFF
--- a/packages/frontend/e2e/keyboard.spec.ts
+++ b/packages/frontend/e2e/keyboard.spec.ts
@@ -58,18 +58,19 @@ test.describe('Keyboard Shortcuts', () => {
   });
 
   test('A toggles autopilot (toast appears)', async ({ app }) => {
-    await app.keyboard.press('a');
-
-    // Toast animates in — look for the visible inner content div (not the wrapper)
-    const toastContent = app.locator('[role="status"] > div');
-    await expect(toastContent).toBeVisible({ timeout: 5000 });
+    await expect(async () => {
+      await app.keyboard.press('a');
+      const toastContent = app.locator('[role="status"] > div');
+      await expect(toastContent).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 10000 });
   });
 
   test('S toggles favorite (toast appears)', async ({ app }) => {
-    await app.keyboard.press('s');
-
-    const toastContent = app.locator('[role="status"] > div');
-    await expect(toastContent).toBeVisible({ timeout: 5000 });
+    await expect(async () => {
+      await app.keyboard.press('s');
+      const toastContent = app.locator('[role="status"] > div');
+      await expect(toastContent).toBeVisible({ timeout: 2000 });
+    }).toPass({ timeout: 10000 });
   });
 
   test('shortcuts are suppressed when focused in search input', async ({ app }) => {

--- a/packages/frontend/playwright.config.ts
+++ b/packages/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   reporter: [['list'], ['html', { open: 'never' }]],
 
   timeout: process.env.CI ? 60_000 : 30_000,


### PR DESCRIPTION
## Summary
- Wrap A and S keyboard shortcut toast tests in `toPass()` retry — keyboard handlers may not be attached when `beforeEach` resolves (same pattern Space/N tests already use)
- Increase CI Playwright workers from 1 to 2 to reduce E2E runtime

## Test plan
- [ ] CI E2E passes clean — no flaky keyboard toast tests
- [ ] E2E runtime noticeably shorter with 2 workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)