### PR TITLE
fix: prevent audio capture race condition and reduce Sentry noise

### DIFF
--- a/packages/frontend/src/hooks/useAudioCapture.ts
+++ b/packages/frontend/src/hooks/useAudioCapture.ts
@@ -81,6 +81,7 @@ export function useAudioCapture(): UseAudioCaptureReturn {
   const engineRef = useRef<AudioEngine | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const trackEndedRef = useRef<(() => void) | null>(null);
+  const startingRef = useRef(false);
   const [audioEngine, setAudioEngine] = useState<AudioEngine | null>(null);
   const [isCapturing, setIsCapturing] = useState(false);
   const [captureSource, setCaptureSource] = useState<CaptureSource>(null);
@@ -108,6 +109,8 @@ export function useAudioCapture(): UseAudioCaptureReturn {
   }, [removeTrackListeners]);
 
   const startCapture = useCallback(async (): Promise<boolean> => {
+    if (startingRef.current) return false;
+    startingRef.current = true;
     try {
       if (engineRef.current) {
         engineRef.current.destroy();
@@ -149,18 +152,24 @@ export function useAudioCapture(): UseAudioCaptureReturn {
         err instanceof DOMException &&
         (err.name === 'NotAllowedError' ||
           err.name === 'AbortError' ||
+          err.name === 'NotSupportedError' ||
           err.name === 'NotReadableError' ||
-          err.name === 'NotFoundError');
+          err.name === 'NotFoundError' ||
+          err.name === 'InvalidStateError');
       if (!isExpected) {
         Sentry.captureException(err, { tags: { audioSource: 'system' } });
       }
       setError(humanizeAudioError(err, 'system'));
       setIsCapturing(false);
       return false;
+    } finally {
+      startingRef.current = false;
     }
   }, [cleanup, removeTrackListeners]);
 
   const startMicCapture = useCallback(async (): Promise<boolean> => {
+    if (startingRef.current) return false;
+    startingRef.current = true;
     try {
       if (engineRef.current) {
         engineRef.current.destroy();
@@ -183,13 +192,16 @@ export function useAudioCapture(): UseAudioCaptureReturn {
           err.name === 'AbortError' ||
           err.name === 'NotSupportedError' ||
           err.name === 'NotReadableError' ||
-          err.name === 'NotFoundError');
+          err.name === 'NotFoundError' ||
+          err.name === 'InvalidStateError');
       if (!isExpected) {
         Sentry.captureException(err, { tags: { audioSource: 'mic' } });
       }
       setError(humanizeAudioError(err, 'mic'));
       setIsCapturing(false);
       return false;
+    } finally {
+      startingRef.current = false;
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Add concurrency guard (`startingRef`) to `startCapture`/`startMicCapture` to prevent `InvalidStateError` from double-clicking "Start Visualizer" before the first async capture completes (MANGOWAVE-1E)
- Add `NotSupportedError` to system capture's expected-error skip list (was missing, already present for mic)
- Add `InvalidStateError` to both capture paths' skip lists — not actionable, shouldn't consume Sentry quota

## Test plan
- [x] All 492 tests pass
- [x] Lint clean
- [ ] Verify double-clicking "Start Visualizer" no longer produces errors in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)