### PR TITLE
fix: audio capture race condition and GLSL optimizer validation

### DIFF
--- a/packages/frontend/src/hooks/useAudioCapture.ts
+++ b/packages/frontend/src/hooks/useAudioCapture.ts
@@ -81,6 +81,7 @@ export function useAudioCapture(): UseAudioCaptureReturn {
   const engineRef = useRef<AudioEngine | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const trackEndedRef = useRef<(() => void) | null>(null);
+  const startingRef = useRef(false);
   const [audioEngine, setAudioEngine] = useState<AudioEngine | null>(null);
   const [isCapturing, setIsCapturing] = useState(false);
   const [captureSource, setCaptureSource] = useState<CaptureSource>(null);
@@ -108,6 +109,8 @@ export function useAudioCapture(): UseAudioCaptureReturn {
   }, [removeTrackListeners]);
 
   const startCapture = useCallback(async (): Promise<boolean> => {
+    if (startingRef.current) return false;
+    startingRef.current = true;
     try {
       if (engineRef.current) {
         engineRef.current.destroy();
@@ -149,18 +152,24 @@ export function useAudioCapture(): UseAudioCaptureReturn {
         err instanceof DOMException &&
         (err.name === 'NotAllowedError' ||
           err.name === 'AbortError' ||
+          err.name === 'NotSupportedError' ||
           err.name === 'NotReadableError' ||
-          err.name === 'NotFoundError');
+          err.name === 'NotFoundError' ||
+          err.name === 'InvalidStateError');
       if (!isExpected) {
         Sentry.captureException(err, { tags: { audioSource: 'system' } });
       }
       setError(humanizeAudioError(err, 'system'));
       setIsCapturing(false);
       return false;
+    } finally {
+      startingRef.current = false;
     }
   }, [cleanup, removeTrackListeners]);
 
   const startMicCapture = useCallback(async (): Promise<boolean> => {
+    if (startingRef.current) return false;
+    startingRef.current = true;
     try {
       if (engineRef.current) {
         engineRef.current.destroy();
@@ -183,13 +192,16 @@ export function useAudioCapture(): UseAudioCaptureReturn {
           err.name === 'AbortError' ||
           err.name === 'NotSupportedError' ||
           err.name === 'NotReadableError' ||
-          err.name === 'NotFoundError');
+          err.name === 'NotFoundError' ||
+          err.name === 'InvalidStateError');
       if (!isExpected) {
         Sentry.captureException(err, { tags: { audioSource: 'mic' } });
       }
       setError(humanizeAudioError(err, 'mic'));
       setIsCapturing(false);
       return false;
+    } finally {
+      startingRef.current = false;
     }
   }, []);
 

--- a/packages/glsl-optimizer-wasm/src/index.js
+++ b/packages/glsl-optimizer-wasm/src/index.js
@@ -46,7 +46,10 @@ export function tryOptimizeGlsl(source) {
   try {
     // shaderType 3 = kGlslTargetOpenGLES30, vertexShader = false
     const result = optimizeGlsl(source, 3, false);
-    if (!result || result.startsWith('Error:')) {
+    if (!result || result.startsWith('Error:') || !result.trimStart().startsWith('#version')) {
+      if (result && !result.startsWith('Error:')) {
+        console.warn('[glsl-optimizer] Optimizer returned invalid output, using original shader');
+      }
       return source;
     }
     return result;


### PR DESCRIPTION
## Summary
- Prevent double-start race condition in `useAudioCapture` via `startingRef` guard — double-tapping "Start Visualizer" could create competing AudioContexts, leaving audio in a broken state
- Validate GLSL optimizer output starts with `#version` before using it — the WASM optimizer can return corrupted output for certain presets (e.g., "Geiss - Cauldron - painterly 2"), causing "invalid character" shader compile errors. Falls back to unoptimized shader gracefully
- Add `NotSupportedError` and `InvalidStateError` to expected Sentry error list to reduce noise

## Test plan
- [x] All 473 unit tests pass
- [x] Lint clean
- [ ] Verify double-tap "Start Visualizer" on mobile doesn't create broken audio state
- [ ] Verify "Geiss - Cauldron - painterly 2 (saturation remix)" preset renders without console shader errors
- [ ] Verify audio reactivity works after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)