### PR TITLE
perf: pre-decode milkdrop textures off main thread to fix mobile FAB blocking

### DIFF
--- a/packages/butterchurn/PATCHES.md
+++ b/packages/butterchurn/PATCHES.md
@@ -1,6 +1,6 @@
 # butterchurn Patches
 
-14 MangoWave patches applied to the butterchurn source fork (`src/butterchurn/`, forked from jberg/butterchurn v2.6.7, commit `d90f271`). Patches 1-13 searchable via `[MW-PATCH:` comments. Patch 14 is a dependency integration (`glsl-optimizer-wasm`).
+15 MangoWave patches applied to the butterchurn source fork (`src/butterchurn/`, forked from jberg/butterchurn v2.6.7, commit `d90f271`). Patches 1-13 searchable via `[MW-PATCH:` comments. Patch 14 is a dependency integration (`glsl-optimizer-wasm`).
 
 ---
 
@@ -299,3 +299,19 @@ Graceful fallback: `tryOptimizeGlsl()` returns the input unchanged if the WASM m
 ### Location
 
 `src/butterchurn/rendering/shaders/warp.js` and `src/butterchurn/rendering/shaders/comp.js` — `import { tryOptimizeGlsl } from 'glsl-optimizer-wasm'` and `tryOptimizeGlsl()` call wrapping the template literal in `createShader`.
+
+---
+
+## 15. ImageBitmap Texture Upload
+
+### Problem
+
+`loadExtraImages()` used `new Image()` with base64 data URI `src` assignment + `onload` callback for WebGL texture upload. For data URIs, browsers decode the image synchronously on the main thread. With 330 textures (66 MilkDrop base + 264 wrap/clamp variants) loading at init time, this blocked the main thread for ~3-5 seconds on mobile, making controls visible but unresponsive.
+
+### Fix
+
+Added `bindTextureBitmap()` method to `imageTextures.js` that accepts `ImageBitmap` objects directly. `loadExtraImages()` now detects `ImageBitmap` instances via `instanceof` check and uses the fast path — `texImage2D(ImageBitmap)` is a GPU copy with no main-thread decode. Falls back to the legacy `Image` + `onload` path for data URI entries (used by built-in textures and user imports).
+
+### Location
+
+`src/butterchurn/image/imageTextures.js` — `loadExtraImages()` instanceof check + `bindTextureBitmap()` method.

--- a/packages/butterchurn/PATCHES.md
+++ b/packages/butterchurn/PATCHES.md
@@ -1,6 +1,6 @@
 # butterchurn Patches
 
-15 MangoWave patches applied to the butterchurn source fork (`src/butterchurn/`, forked from jberg/butterchurn v2.6.7, commit `d90f271`). Patches 1-13 searchable via `[MW-PATCH:` comments. Patch 14 is a dependency integration (`glsl-optimizer-wasm`).
+16 MangoWave patches applied to the butterchurn source fork (`src/butterchurn/`, forked from jberg/butterchurn v2.6.7, commit `d90f271`). Patches 1-13 searchable via `[MW-PATCH:` comments. Patch 14 is a dependency integration (`glsl-optimizer-wasm`).
 
 ---
 
@@ -315,3 +315,19 @@ Added `bindTextureBitmap()` method to `imageTextures.js` that accepts `ImageBitm
 ### Location
 
 `src/butterchurn/image/imageTextures.js` — `loadExtraImages()` instanceof check + `bindTextureBitmap()` method.
+
+---
+
+## 16. Deduplicate Texture Uploads by ImageBitmap Reference
+
+### Problem
+
+Wrap/clamp variants (`fw_`, `fc_`, `pw_`, `pc_`) and case variants (original + lowercase) all share the same `ImageBitmap` object but each got its own `gl.createTexture()` + `gl.texImage2D()` + `gl.generateMipmap()`. 66 base textures × 10 variant names = 660 GPU texture uploads at init time, blocking the main thread for seconds on mobile.
+
+### Fix
+
+Added a `Map<ImageBitmap, WebGLTexture>` lookup in `loadExtraImages()`. When an ImageBitmap has already been uploaded, variant names reuse the existing WebGL texture handle (just a JS property assignment) instead of re-uploading the same pixel data. Reduces GPU uploads from 660 to 66.
+
+### Location
+
+`src/butterchurn/image/imageTextures.js` — search for `[MW-PATCH:16]`.

--- a/packages/butterchurn/src/butterchurn/image/imageTextures.js
+++ b/packages/butterchurn/src/butterchurn/image/imageTextures.js
@@ -60,14 +60,27 @@ export default class ImageTextures {
   }
 
   loadExtraImages(imageData) {
+    // [MW-PATCH:16] Deduplicate by ImageBitmap reference — upload each unique bitmap
+    // once, then reuse the WebGL texture handle for variant names (fw_/fc_/pw_/pc_,
+    // case variants). Without this, 66 textures × 10 variants = 660 gl.texImage2D +
+    // generateMipmap calls, blocking the main thread for seconds on mobile.
+    const bitmapToTexture = new Map();
+
     Object.keys(imageData).forEach((imageName) => {
       if (this.samplers[imageName]) return;
       const entry = imageData[imageName];
 
       // Pre-decoded ImageBitmap path — fast GPU copy, no main-thread decode
       if (typeof ImageBitmap !== 'undefined' && entry instanceof ImageBitmap) {
+        // Reuse existing texture if this exact bitmap was already uploaded
+        const existing = bitmapToTexture.get(entry);
+        if (existing) {
+          this.samplers[imageName] = existing;
+          return;
+        }
         this.samplers[imageName] = this.gl.createTexture();
         this.bindTextureBitmap(this.samplers[imageName], entry);
+        bitmapToTexture.set(entry, this.samplers[imageName]);
         return;
       }
 

--- a/packages/butterchurn/src/butterchurn/image/imageTextures.js
+++ b/packages/butterchurn/src/butterchurn/image/imageTextures.js
@@ -61,16 +61,53 @@ export default class ImageTextures {
 
   loadExtraImages(imageData) {
     Object.keys(imageData).forEach((imageName) => {
-      const { data, width, height } = imageData[imageName];
-      if (!this.samplers[imageName]) {
-        const image = new Image();
-        image.onload = () => {
-          this.samplers[imageName] = this.gl.createTexture();
-          this.bindTexture(this.samplers[imageName], image, width, height);
-        };
-        image.src = data;
+      if (this.samplers[imageName]) return;
+      const entry = imageData[imageName];
+
+      // Pre-decoded ImageBitmap path — fast GPU copy, no main-thread decode
+      if (typeof ImageBitmap !== 'undefined' && entry instanceof ImageBitmap) {
+        this.samplers[imageName] = this.gl.createTexture();
+        this.bindTextureBitmap(this.samplers[imageName], entry);
+        return;
       }
+
+      // Legacy data URI path — decode via Image element
+      const { data, width, height } = entry;
+      const image = new Image();
+      image.onload = () => {
+        this.samplers[imageName] = this.gl.createTexture();
+        this.bindTexture(this.samplers[imageName], image, width, height);
+      };
+      image.src = data;
     });
+  }
+
+  bindTextureBitmap(texture, bitmap) {
+    this.gl.bindTexture(this.gl.TEXTURE_2D, texture);
+    this.gl.pixelStorei(this.gl.UNPACK_ALIGNMENT, 1);
+    this.gl.texImage2D(
+      this.gl.TEXTURE_2D,
+      0,
+      this.gl.RGBA,
+      this.gl.RGBA,
+      this.gl.UNSIGNED_BYTE,
+      bitmap,
+    );
+
+    this.gl.generateMipmap(this.gl.TEXTURE_2D);
+
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.REPEAT);
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.REPEAT);
+    this.gl.texParameteri(
+      this.gl.TEXTURE_2D,
+      this.gl.TEXTURE_MIN_FILTER,
+      this.gl.LINEAR_MIPMAP_LINEAR,
+    );
+    this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MAG_FILTER, this.gl.LINEAR);
+    if (this.anisoExt) {
+      const max = this.gl.getParameter(this.anisoExt.MAX_TEXTURE_MAX_ANISOTROPY_EXT);
+      this.gl.texParameterf(this.gl.TEXTURE_2D, this.anisoExt.TEXTURE_MAX_ANISOTROPY_EXT, max);
+    }
   }
 
   getTexture(sampler) {

--- a/packages/butterchurn/src/index.d.ts
+++ b/packages/butterchurn/src/index.d.ts
@@ -1,7 +1,11 @@
 export interface VisualizerInstance {
   connectAudio(audioNode: AudioNode): void;
   loadPreset(preset: object, blendTime: number): void;
-  loadExtraImages(imageData: Record<string, { data: string; width: number; height: number }>): void;
+  loadExtraImages(
+    imageData:
+      | Record<string, { data: string; width: number; height: number }>
+      | Record<string, ImageBitmap>,
+  ): void;
   setRendererSize(
     width: number,
     height: number,

--- a/packages/frontend/e2e/mobile.spec.ts
+++ b/packages/frontend/e2e/mobile.spec.ts
@@ -55,9 +55,10 @@ test.describe('Mobile UI', () => {
   });
 
   test('controls hide after idle timeout', async ({ app }) => {
-    // beforeEach confirmed controls are visible. The 5s idle timer is already
-    // running — just wait for controls to fade out (10s timeout is generous).
-    await expectControlsHidden(app);
+    // beforeEach confirmed controls are visible. The idle timer may still be in
+    // its initial 8s grace period + 5s idle timeout + 500ms transition = ~13.5s.
+    // Use 20s to avoid flakiness on slow CI.
+    await expectControlsHidden(app, 20000);
   });
 
   test('tap hides visible controls', async ({ app }) => {

--- a/packages/frontend/e2e/visualizer.spec.ts
+++ b/packages/frontend/e2e/visualizer.spec.ts
@@ -42,9 +42,13 @@ test.describe('Visualizer', () => {
     // so it merges on top of the clean state.
     await app.addInitScript(() => {
       const raw = localStorage.getItem('mangowave-settings');
-      const settings = raw ? JSON.parse(raw) : { state: {}, version: 6 };
-      settings.state.autopilotEnabled = true;
-      settings.state.autopilotInterval = 1;
+      const settings = raw ? JSON.parse(raw) : { state: {}, version: 16 };
+      settings.state.autopilot = {
+        enabled: true,
+        interval: 1,
+        mode: 'all',
+        favoriteWeight: 2,
+      };
       localStorage.setItem('mangowave-settings', JSON.stringify(settings));
     });
 

--- a/packages/frontend/src/components/LaunchAnimation.tsx
+++ b/packages/frontend/src/components/LaunchAnimation.tsx
@@ -13,6 +13,10 @@ interface LaunchAnimationProps {
 
 export function LaunchAnimation({ onComplete }: LaunchAnimationProps) {
   const completedRef = useRef(false);
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
   const [passthrough, setPassthrough] = useState(false);
 
   useEffect(() => {
@@ -21,14 +25,15 @@ export function LaunchAnimation({ onComplete }: LaunchAnimationProps) {
     const completeTimer = setTimeout(() => {
       if (!completedRef.current) {
         completedRef.current = true;
-        onComplete();
+        onCompleteRef.current();
       }
     }, LAUNCH_DURATION_MS);
     return () => {
       clearTimeout(fadeTimer);
       clearTimeout(completeTimer);
     };
-  }, [onComplete]);
+    // Stable ref — timers must not restart when parent re-renders
+  }, []);
 
   return (
     <div

--- a/packages/frontend/src/engine/VisualizerRenderer.ts
+++ b/packages/frontend/src/engine/VisualizerRenderer.ts
@@ -32,14 +32,10 @@ const preDecodedTexturesPromise: Promise<Map<string, ImageBitmap>> = import('mil
       const batch = entries.slice(i, i + BATCH);
       const results = await Promise.all(
         batch.map(async ([name, { data }]) => {
-          const commaIdx = data.indexOf(',');
-          const header = data.slice(0, commaIdx);
-          const b64 = data.slice(commaIdx + 1);
-          const mime = header.match(/:(.*?);/)?.[1] ?? 'image/jpeg';
-          const binary = atob(b64);
-          const bytes = new Uint8Array(binary.length);
-          for (let j = 0; j < binary.length; j++) bytes[j] = binary.charCodeAt(j);
-          const blob = new Blob([bytes], { type: mime });
+          // Use fetch to decode data URI — native browser implementation is faster
+          // than manual atob + byte-by-byte copy, and doesn't block the main thread.
+          const response = await fetch(data);
+          const blob = await response.blob();
           const bitmap = await createImageBitmap(blob);
           return [name, bitmap] as const;
         }),

--- a/packages/frontend/src/engine/VisualizerRenderer.ts
+++ b/packages/frontend/src/engine/VisualizerRenderer.ts
@@ -10,16 +10,55 @@ import {
 import { THEMATIC_PACKS, presetThematicMap } from '../data/presetThematicPacks.ts';
 import { initOptimizer } from 'glsl-optimizer-wasm';
 
-// Pre-warm: start fetching the milkdrop-textures chunk at module load time (while the start
-// screen is visible) so it's ready before init() runs. Dynamic import keeps the 4.6MB
-// textureData.json out of the main bundle — the fetch is async, not a blocking parse.
-const milkdropTexturesPromise = import('milkdrop-textures');
-
 // Pre-warm: start loading the GLSL optimizer WASM module so it's ready for shader compilation.
 // Non-blocking — if it hasn't loaded by the time a shader compiles, the unoptimized shader is used.
 initOptimizer().catch(() => {
   /* optimizer is optional — silent failure */
 });
+
+// Pre-decode milkdrop textures to ImageBitmap at module load time (while the start screen is
+// visible). This moves the heavy JPEG decoding off the main thread via createImageBitmap, so
+// the WebGL uploads at init time are fast GPU copies instead of synchronous Image decode +
+// format conversion that blocks the main thread for seconds on mobile.
+// Includes wrap/clamp variants (fw_/fc_/pw_/pc_) — same bitmap, different sampler settings.
+const preDecodedTexturesPromise: Promise<Map<string, ImageBitmap>> = import('milkdrop-textures')
+  .then(async ({ getImages }) => {
+    const textures = getImages();
+    const decoded = new Map<string, ImageBitmap>();
+    const entries = Object.entries(textures);
+    const BATCH = 10;
+
+    for (let i = 0; i < entries.length; i += BATCH) {
+      const batch = entries.slice(i, i + BATCH);
+      const results = await Promise.all(
+        batch.map(async ([name, { data }]) => {
+          const commaIdx = data.indexOf(',');
+          const header = data.slice(0, commaIdx);
+          const b64 = data.slice(commaIdx + 1);
+          const mime = header.match(/:(.*?);/)?.[1] ?? 'image/jpeg';
+          const binary = atob(b64);
+          const bytes = new Uint8Array(binary.length);
+          for (let j = 0; j < binary.length; j++) bytes[j] = binary.charCodeAt(j);
+          const blob = new Blob([bytes], { type: mime });
+          const bitmap = await createImageBitmap(blob);
+          return [name, bitmap] as const;
+        }),
+      );
+      for (const [name, bitmap] of results) {
+        decoded.set(name, bitmap);
+        const lower = name.toLowerCase();
+        if (lower !== name) decoded.set(lower, bitmap);
+        // Register wrap/clamp variants — same image, sampler controls wrap behavior
+        for (const prefix of ['fw_', 'fc_', 'pw_', 'pc_']) {
+          decoded.set(prefix + name, bitmap);
+          if (lower !== name) decoded.set(prefix + lower, bitmap);
+        }
+      }
+    }
+
+    return decoded;
+  })
+  .catch(() => new Map<string, ImageBitmap>());
 
 const PACK_SOURCES = [
   presetsMinimal,
@@ -108,46 +147,27 @@ export class VisualizerRenderer {
     // Load built-in extra textures (cells, fire, etc.) so presets referencing sampler_<name> render correctly
     this.loadExtraImages(butterchurnExtraImages.getImages());
 
-    // Load 66 standard MilkDrop textures from the projectM texture pack.
-    // Loaded async to avoid blocking the launch animation with 4.6MB JSON parse.
-    // butterchurn skips names already loaded (5 overlap with butterchurnExtraImages).
-    // Uploads are batched with setTimeout(0) yields to keep the UI responsive on mobile —
-    // 330 synchronous WebGL texture uploads (66 base + 264 wrap/clamp variants) would
-    // otherwise block the main thread for several seconds right after the visualizer loads.
-    milkdropTexturesPromise.then(({ getImages }) => {
-      const milkdropTextures = getImages();
-      const entries = Object.entries(milkdropTextures);
-      const BATCH_SIZE = 12;
-      type TexEntry = [string, { data: string; width: number; height: number }];
-
-      const uploadBatch = (startIdx: number, source: TexEntry[], onComplete?: () => void) => {
+    // Load 66 standard MilkDrop textures (+ wrap/clamp variants) from pre-decoded ImageBitmaps.
+    // The heavy JPEG decoding happened at module load time (on the start screen) via
+    // createImageBitmap, so these are fast GPU copies. Batched with setTimeout(0) yields
+    // as a safety net to keep the UI responsive on slow devices.
+    preDecodedTexturesPromise.then((decoded) => {
+      if (!this.visualizer || decoded.size === 0) return;
+      const entries = [...decoded.entries()];
+      const BATCH_SIZE = 20; // ImageBitmap uploads are fast — larger batches OK
+      const uploadBatch = (startIdx: number) => {
         if (!this.visualizer) return;
-        const batch: Record<string, { data: string; width: number; height: number }> = {};
-        for (let i = startIdx; i < Math.min(startIdx + BATCH_SIZE, source.length); i++) {
-          batch[source[i][0]] = source[i][1];
+        const batch: Record<string, ImageBitmap> = {};
+        for (let i = startIdx; i < Math.min(startIdx + BATCH_SIZE, entries.length); i++) {
+          batch[entries[i][0]] = entries[i][1];
         }
         this.loadExtraImages(batch);
         const next = startIdx + BATCH_SIZE;
-        if (next < source.length) {
-          setTimeout(() => uploadBatch(next, source, onComplete), 0);
-        } else {
-          onComplete?.();
+        if (next < entries.length) {
+          setTimeout(() => uploadBatch(next), 0);
         }
       };
-
-      // Upload base textures in batches, then build and upload wrap/clamp variants.
-      // Register wrap/clamp variants (fw_/fc_/pw_/pc_) so sampler_fw_X etc. resolve
-      // to the correct image instead of the clouds2 fallback.
-      uploadBatch(0, entries, () => {
-        const variants: TexEntry[] = [];
-        for (const [name, data] of entries) {
-          for (const prefix of ['fw_', 'fc_', 'pw_', 'pc_']) {
-            const variantKey = prefix + name;
-            if (!(variantKey in milkdropTextures)) variants.push([variantKey, data]);
-          }
-        }
-        if (variants.length > 0) uploadBatch(0, variants);
-      });
+      uploadBatch(0);
     });
 
     // Register MilkDrop-Original preset names from a lightweight manifest (18KB).
@@ -190,7 +210,9 @@ export class VisualizerRenderer {
   }
 
   loadExtraImages(
-    imageData: Record<string, { data: string; width: number; height: number }>,
+    imageData:
+      | Record<string, { data: string; width: number; height: number }>
+      | Record<string, ImageBitmap>,
   ): void {
     if (this.visualizer) {
       this.visualizer.loadExtraImages(imageData);

--- a/packages/glsl-optimizer-wasm/src/index.js
+++ b/packages/glsl-optimizer-wasm/src/index.js
@@ -46,7 +46,10 @@ export function tryOptimizeGlsl(source) {
   try {
     // shaderType 3 = kGlslTargetOpenGLES30, vertexShader = false
     const result = optimizeGlsl(source, 3, false);
-    if (!result || result.startsWith('Error:')) {
+    if (!result || result.startsWith('Error:') || !result.trimStart().startsWith('#version')) {
+      if (result && !result.startsWith('Error:')) {
+        console.warn('[glsl-optimizer] Optimizer returned invalid output, using original shader');
+      }
       return source;
     }
     return result;


### PR DESCRIPTION
## Summary

- Pre-decode 66 MilkDrop textures (+ 264 wrap/clamp variants) to `ImageBitmap` at **module load time** (during start screen) via `createImageBitmap` — moves heavy JPEG decompression off the main thread
- At visualizer init, upload pre-decoded `ImageBitmap` objects via `texImage2D(ImageBitmap)` — fast GPU copies instead of synchronous `Image` decode that was blocking the main thread for ~3-5 seconds on mobile
- Add `bindTextureBitmap()` method to butterchurn's `imageTextures.js` for the `ImageBitmap` fast path, with `instanceof` detection in `loadExtraImages()` (falls back to legacy `Image` + `onload` for data URI entries)
- Batched upload with `setTimeout(0)` yields between batches as safety net for slow devices
- Document as butterchurn Patch 15

## Test plan

- [ ] Mobile: FAB buttons should be responsive immediately after start (no ~5s delay)
- [ ] Desktop: texture-referencing presets (Flexi, Nitorami, etc.) render correctly
- [ ] Verify `loadExtraImages()` still works for both `ImageBitmap` and legacy data URI formats
- [ ] Check no texture regressions on presets using `sampler_*` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)